### PR TITLE
[WIP] Update to using metadata file

### DIFF
--- a/ads1115.meta
+++ b/ads1115.meta
@@ -1,0 +1,70 @@
+{
+  "0": {
+    "llType": "error",
+    "columns": [
+      {
+        "llabel": "error message",
+        "dtype": "str"
+      }
+    ]
+  },
+  "100": {
+    "llType": "channel0",
+    "columns": [
+      {
+        "llabel": "data",
+        "detail": "ADC channel 0",
+        "units": "V",
+        "dtype": "float"
+      }
+    ]
+  },
+  "101": {
+    "llType": "channel1",
+    "columns": [
+      {
+        "llabel": "data",
+        "detail": "ADC channel 1",
+        "units": "V",
+        "dtype": "float"
+      }
+    ]
+  },
+  "102": {
+    "llType": "channel2",
+    "columns": [
+      {
+        "llabel": "data",
+        "detail": "ADC Channel 2",
+        "units": "V",
+        "dtype": "float"
+      }
+    ]
+  },
+  "103": {
+    "llType": "channel3",
+    "columns": [
+      {
+        "llabel": "data",
+        "detail": "ADC Channel 3",
+        "units": "V",
+        "dtype": "float"
+      }
+    ]
+  },
+  "2": {
+    "llType": "configuration",
+    "columns": [
+      {
+        "llabel": "gain",
+        "detail": "PGA Gain",
+        "dtype": "int"
+      },
+      {
+        "llabel": "ODR",
+        "detail": "Operating Data Rate",
+        "dtype": "int"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Part of https://github.com/bluerobotics/navigator-validation/issues/5

Uses custom log types (100-103) for ADC channel data (only data from one channel per row). Implement similar to in [`system.py`](https://github.com/jaxxzer/navigator-validation/blob/system/src/test-system.py#L86-L92)

ODR detail may be incorrect (best guess was Operating Data Rate). -> should be 'Output Data Rate' (TODO, fix)